### PR TITLE
update references to CRD definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Includes:
 * Go version >= 1.23
 * hugo (`dnf install hugo`)
 * entr (`dnf install entr`)
-* Must have cloned "ec-cli", "ec-policies", "user-guide", and "enterprise-contract-controller" repositories at the same level as this repo ("conforma.github.io")
+* Must have cloned "conforma/cli", "conforma/policy", "conforma/user-guide", and "conforma/crds" repositories at the same level as this repo ("conforma.github.io")
 
 ## Live reload preview
 

--- a/antora/antora-playbook.yml
+++ b/antora/antora-playbook.yml
@@ -32,7 +32,7 @@ content:
     - url: https://github.com/conforma/cli.git
       start_path: docs
 
-    - url: https://github.com/enterprise-contract/enterprise-contract-controller.git
+    - url: https://github.com/conforma/crds.git
       start_path: docs
 
     - url: https://github.com/conforma/user-guide.git

--- a/website/content/posts/introducing-the-enterprise-contract.md
+++ b/website/content/posts/introducing-the-enterprise-contract.md
@@ -265,9 +265,9 @@ Notice the additional information in the output. It contains a list of policy ru
 successfully evaluated as well as the details for the policy used.
 
 To improve reusability, the `policy.yaml` file can be stored in your Kubernetes clusters via the
-[EnterpriseContractPolicy](https://github.com/enterprise-contract/enterprise-contract-controller)
+[EnterpriseContractPolicy](https://github.com/conforma/crds)
 custom resource, see
-[example](https://github.com/enterprise-contract/enterprise-contract-controller/blob/main/config/samples/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy.yaml).
+[example](https://github.com/conforma/crds/blob/main/config/samples/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy.yaml).
 
 Say now that you have a group of images, an “application snapshot”, that must all pass validation.
 We can do this in one shot by creating the components.yaml file:


### PR DESCRIPTION
This commit updates references for the CRD definitions from `github.com/enterprise-contract/enterprise-contract-controller` to `github.com/conforma/crds`  

Ref: EC-1422
Signed-off-by: Rob Nester <rnester@redhat.com>